### PR TITLE
Export the module name rather than the module itself.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,8 +39,9 @@ function ngHtml2jsify(opts) {
       try {
         fileName = opts.baseDir ? file.replace(path.join(appDir, opts.baseDir), '').replace(/\\/g, '/') : file.match(fileMatching)[1];
         fileName = opts.prefix + fileName;
+
         content = fs.readFileSync(file, 'utf-8');
-        src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = ngModule;';
+        src = ngHtml2Js(fileName, content, opts.module, 'ngModule') + '\nmodule.exports = \'' + fileName + '\';';
       } catch (error) {
         this.emit('error', error);
       }


### PR DESCRIPTION
/cc @isuda

This allows for Angular directive code that looks like this:

``` javascript
var template = require('foo.tpl.html');

angular.module('fooDirective', [template])
.directive('foo', function() {
  return {
    templateUrl: template
  };
});
```
